### PR TITLE
RFC 36: added register and unregister mouse/key listeners

### DIFF
--- a/Input.hpp
+++ b/Input.hpp
@@ -2,6 +2,8 @@
 #define INPUT_H_
 
 #include "Point.hpp"
+#include "IKeyListener.hpp"
+#include "IMouseListener.hpp"
 #include <string>
 
 namespace spic {
@@ -317,6 +319,29 @@ namespace spic {
          */
         bool GetMouseButtonUp(MouseButton which);
 
+        /**
+         * Register a new key listener
+         * @param listener A reference to a key listener
+         */
+        void RegisterKeyListener(IKeyListener& listener);
+
+        /**
+         * Unregister a key listener
+         * @param listener A reference to a key listener
+         */
+        void UnregisterKeyListener(IKeyListener& listener);
+
+        /**
+         * Register a new mouse listener
+         * @param listener A reference to a mouse listener
+         */
+        void RegisterMouseListener(IMouseListener& listener);
+
+        /**
+         * Unregister a mouse listener
+         * @param listener A reference to a mouse listener
+         */
+        void UnregisterMouseListener(IMouseListener& listener);
     }
 
 }


### PR DESCRIPTION
De parameters zijn gewone references in plaats van `const` references, omdat de classe die de listener implementeerd mogelijk zichzelf wil wijzigen wanneer hij zo'n event ontvangt.