### PR TITLE
RFC 38, 41, 42: GameObject refactoring

### DIFF
--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -80,23 +80,23 @@ namespace spic {
             GameObject(const std::string& name, const std::string& tag, int layer);
 
             /**
-             * @brief Does the object exist? TODO wat wordt hiermee bedoeld?
+             * @brief Does the object exist?
              */
-            operator bool();
+            operator bool() const;
 
             /**
              * @brief Compare two GameObjects.
              * @param other The other object to compare this one with.
              * @return true if not equal, false otherwise.
              */
-            bool operator!=(const GameObject& other);
+            bool operator!=(const GameObject& other) const;
 
             /**
              * @brief Compare two GameObjects
              * @param other The other object to compare this one with.
              * @return true if equal, false otherwise.
              */
-            bool operator==(const GameObject& other);
+            bool operator==(const GameObject& other) const;
 
             /**
              * @brief Add a Component of the specified type. Must be a valid
@@ -185,7 +185,13 @@ namespace spic {
              * @brief Returns the transform of this GameObject
              * @return A reference to the transform
              */
-            spic::Transform& Transform() const;
+            spic::Transform& Transform();
+
+            const std::string& Name() { return name; }
+
+            const std::string& Tag() { return tag; }
+
+            const int Layer() { return layer; }
 
         private:
             std::string name;

--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -191,7 +191,7 @@ namespace spic {
 
             const std::string& Tag() { return tag; }
 
-            const int Layer() { return layer; }
+            int Layer() { return layer; }
 
         private:
             std::string name;

--- a/Scene.hpp
+++ b/Scene.hpp
@@ -1,7 +1,6 @@
 #ifndef SCENE_H_
 #define SCENE_H_
 
-#include "GameObject.hpp"
 #include <vector>
 #include <memory>
 

--- a/Scene.hpp
+++ b/Scene.hpp
@@ -10,6 +10,8 @@
 
 namespace spic {
 
+    class GameObject;
+
     /**
      * @brief Class representing a scene which can be rendered by the Camera.
      */


### PR DESCRIPTION
GameObject:
- operator methods const maken
- Transform() mag geen const zijn als we deze direct willen gaan wijzigen
- Getters toegevoegd voor Name, Tag, Layer

Scene:
- Bugfix circulaire dependency met GameObject

Opgelost door een forward declaration in Scene.hpp die in Scene.cpp als volgt gebruikt moet worden:
```
#include "GameObject.cpp"
```