### PR TITLE
RFC 43: Voeg ook een const reference naar Transform toe

### DIFF
--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -187,6 +187,12 @@ namespace spic {
              */
             spic::Transform& Transform();
 
+            /**
+             * @brief Returns a const reference to the transform of this GameObject
+             * @return A const reference to the transform
+             */
+            const spic::Transform& Transform() const;
+
             const std::string& Name() { return name; }
 
             const std::string& Tag() { return tag; }


### PR DESCRIPTION
De functie waarmee we text renderen verwacht een const ref naar Text, wat logisch is want const correct, maar omdat we daar ook de position op willen vragen van de transform, die niet const is, kan dat niet compilen.