### PR TITLE
RFC 51: Feature/remove private impls that are not in bob edition

### DIFF
--- a/Animator.hpp
+++ b/Animator.hpp
@@ -14,6 +14,7 @@ namespace spic {
 
     /**
      * @brief A component which can play animated sequences of sprites.
+     * @spicapi
      */
     class Animator : public Component {
         public:

--- a/Animator.hpp
+++ b/Animator.hpp
@@ -21,6 +21,7 @@ namespace spic {
              * @brief Constructor.
              * @param fps The amount of frames the animator will cycle though per second.
              * @param sprites An list of sprites to loop through.
+             * @sharedapi
              */
             Animator(int fps, const std::vector<std::shared_ptr<Sprite>>& sprites);
 
@@ -41,12 +42,14 @@ namespace spic {
             /**
              * @brief Get the frames per second of the animator
              * @return An integer representing the frames per second of the animator
+             * @sharedapi
              */
             int FPS() const;
 
             /**
              * @brief Set the new frames per second of the animator
              * @param newFps An integer representing the new frames per second of the animator
+             * @sharedapi
              */
             void FPS(int newFps);
 
@@ -56,11 +59,6 @@ namespace spic {
              * @spicapi
              */
             int fps;
-
-            /**
-             * @brief collection of Sprites to cycle through
-             */
-            std::vector<std::shared_ptr<Sprite>> sprites;
 
 #if __has_include("Animator_private.hpp")
 #include "Animator_private.hpp"

--- a/AudioSource.hpp
+++ b/AudioSource.hpp
@@ -12,6 +12,7 @@ namespace spic {
 
     /**
      * @brief Component which can play audio.
+     * @spicapi
      */
     class AudioSource : public Component {
         public:

--- a/AudioSource.hpp
+++ b/AudioSource.hpp
@@ -19,6 +19,7 @@ namespace spic {
              * @brief Constructor.
              * @param audioClip The source tho the audio clip.
              * @param playOnAwake Whether the audio should start playing automatically.
+             * @sharedapi
              */
             AudioSource(const std::string& audioClip, bool playOnAwake);
 
@@ -38,33 +39,39 @@ namespace spic {
             /**
              * @brief Get the volume of the AudioSource
              * @return The volume of the AudioSource, which is a double between 0.0 and 1.0 inclusively
+             * @sharedapi
              */
             double Volume() const;
 
             /**
              * @brief Set volume of the AudioSource
              * @param newVolume The new volume level of the AudioSource
+             * @sharedapi
              */
             void Volume(double newVolume);
 
         private:
             /**
              * @brief Path to a locally stored audio file.
+             * @spicapi
              */
             std::string audioClip;
 
             /**
              * @brief When true, the component will start playing automatically.
+             * @spicapi
              */
             bool playOnAwake;
 
             /**
              * @brief When true, the audio will play indefinitely.
+             * @spicapi
              */
             bool loop;
 
             /**
              * @brief Audio volume, between 0.0 and 1.0.
+             * @spicapi
              */
             double volume;
 

--- a/BehaviourScript.hpp
+++ b/BehaviourScript.hpp
@@ -48,12 +48,14 @@ namespace spic {
             /**
              * @brief Whether the script has been started.
              * @param started desired value
+             * @sharedapi
              */
             void Started(bool started);
 
             /**
              * @brief Whether the script has been started.
              * @return current value
+             * @sharedapi
              */
             bool Started() const;
 

--- a/BoxCollider.hpp
+++ b/BoxCollider.hpp
@@ -7,6 +7,7 @@ namespace spic {
 
     /**
      * @brief A collider which represents a rectangular collision area.
+     * @spicapi
      */
     class BoxCollider : public Collider {
         public:

--- a/BoxCollider.hpp
+++ b/BoxCollider.hpp
@@ -12,6 +12,7 @@ namespace spic {
         public:
             /**
              * @brief Constructor.
+             * @sharedapi
              */
             BoxCollider();
 
@@ -19,6 +20,7 @@ namespace spic {
              * @brief Constructor.
              * @param width The width for the box collider.
              * @param height The height for the box collider.
+             * @sharedapi
              */
             BoxCollider(double width, double height);
 

--- a/Button.hpp
+++ b/Button.hpp
@@ -12,6 +12,7 @@ namespace spic {
 
     /**
      * @brief Instances of this class are clickable user interface items.
+     * @spicapi
      */
     class Button : public UIObject {
         public:

--- a/Button.hpp
+++ b/Button.hpp
@@ -22,6 +22,7 @@ namespace spic {
              * @param layer The layer for the game object.
              * @param width The width of the UI object.
              * @param height The height of the UI object.
+             * @sharedapi
              */
             Button(const std::string& name, const std::string& tag, int layer, double width, double height);
 
@@ -43,23 +44,27 @@ namespace spic {
             /**
              * @brief Get if the button is interactable
              * @return A boolean flag if the button is interactable or not
+             * @sharedapi
              */
             bool Interactable() const;
 
             /**
              * @brief Set if the button is interactable
              * @param isInteractable A new boolean value to define if the button should be interactable or not
+             * @sharedapi
              */
             void Interactable(bool isInteractable);
 
         private:
             /**
              * @brief When false, the button will not react to clicks.
+             * @spicapi
              */
             bool interactable;
 
             /**
              * @brief The registered click handler.
+             * @spicapi
              */
             std::function<void()> onClick;
 

--- a/Camera.hpp
+++ b/Camera.hpp
@@ -17,6 +17,7 @@ namespace spic {
              * @param backgroundColor The background color of the horizon in the camera.
              * @param aspectWidth The aspect width of the camera.
              * @param aspectHeight The aspect width of the camera.
+             * @sharedapi
              */
             Camera(const Color& backgroundColor, double aspectWidth, double aspectHeight);
 

--- a/Camera.hpp
+++ b/Camera.hpp
@@ -21,6 +21,48 @@ namespace spic {
              */
             Camera(const Color& backgroundColor, double aspectWidth, double aspectHeight);
 
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            const Color& BackgroundColor() const;
+
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            void BackgroundColor(const Color& newBackgroundColor);
+
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            double AspectWidth() const;
+
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            void AspectWidth(double newAspectWidth);
+
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            double AspectHeight() const;
+
+            /**
+             *
+             * @return
+             * @sharedapi
+             */
+            void AspectHeight(double newAspectHeight);
+
         private:
             Color backgroundColor;
             double aspectWidth;

--- a/Camera.hpp
+++ b/Camera.hpp
@@ -21,48 +21,6 @@ namespace spic {
              */
             Camera(const Color& backgroundColor, double aspectWidth, double aspectHeight);
 
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            const Color& BackgroundColor() const;
-
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            void BackgroundColor(const Color& newBackgroundColor);
-
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            double AspectWidth() const;
-
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            void AspectWidth(double newAspectWidth);
-
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            double AspectHeight() const;
-
-            /**
-             *
-             * @return
-             * @sharedapi
-             */
-            void AspectHeight(double newAspectHeight);
-
         private:
             Color backgroundColor;
             double aspectWidth;

--- a/CircleCollider.hpp
+++ b/CircleCollider.hpp
@@ -7,6 +7,7 @@ namespace spic {
 
     /**
      * @brief A collider which represents a circular collision area.
+     * @spicapi
      */
     class CircleCollider : public Collider {
         public:

--- a/CircleCollider.hpp
+++ b/CircleCollider.hpp
@@ -12,12 +12,14 @@ namespace spic {
         public:
             /**
              * @brief Constructor.
+             * @sharedapi
              */
             CircleCollider();
 
             /**
              * @brief Constructor.
              * @param radius The radius for the box collider.
+             * @sharedapi
              */
             CircleCollider(double radius);
 

--- a/Collider.hpp
+++ b/Collider.hpp
@@ -19,12 +19,14 @@ namespace spic {
         /**
          * @brief Get if the collider is a trigger
          * @return True if the collider is a trigger, false if not
+         * @sharedapi
          */
         bool IsTrigger() const;
 
         /**
          * @brief Set if the collider is a trigger
          * @param newIsTrigger A new value to define if the collider is a trigger
+         * @sharedapi
          */
         void IsTrigger(bool newIsTrigger);
 

--- a/Color.hpp
+++ b/Color.hpp
@@ -5,6 +5,7 @@ namespace spic {
 
     /**
      * @brief Color represents a red-green-blue color with alpha.
+     * @spicapi
      */
     class Color {
         public:

--- a/Color.hpp
+++ b/Color.hpp
@@ -13,6 +13,7 @@ namespace spic {
              * @param red The red component, 0 ≤ r ≤ 1.
              * @param green The green component, 0 ≤ g ≤ 1.
              * @param blue The blue component, 0 ≤ b ≤ 1.
+             * @sharedapi
              */
             Color(double red, double green, double blue);
             
@@ -85,26 +86,30 @@ namespace spic {
             /**
              * @brief One of the standard colors (read-only): purple.
              * @return A reference to a statically allocated Color instance.
+             * @sharedapi
              */
-            static const Color& purple() { return _purple; }
+            static const Color& purple();
 
             /**
              * @brief One of the standard colors (read-only): lime.
              * @return A reference to a statically allocated Color instance.
+             * @sharedapi
              */
-            static const Color& lime() { return _lime; }
+            static const Color& lime();
 
             /**
              * @brief One of the standard colors (read-only): orange.
              * @return A reference to a statically allocated Color instance.
+             * @sharedapi
              */
-            static const Color& orange() { return _orange; }
+            static const Color& orange();
 
             /**
              * @brief One of the standard colors (read-only): transparent.
              * @return A reference to a statically allocated Color instance.
+             * @sharedapi
              */
-            static const Color& transparent() { return _transparent; }
+            static const Color& transparent();
             // ... more standard colors here
 
             /**
@@ -112,6 +117,7 @@ namespace spic {
              * @param r The red part of the color
              * @param g The green part of the color
              * @param b The blue part of the color
+             * @sharedapi
              */
             void SetColor(double r, double g, double b);
 
@@ -121,32 +127,37 @@ namespace spic {
              * @param g The green part of the color
              * @param b The blue part of the color
              * @param a The alpha part of the color
+             * @sharedapi
              */
             void SetColor(double r, double g, double b, double a);
             
             /**
              * @brief The red part of the color
              * @return A reference to the statically red part of the color.
+             * @sharedapi
              */
-            double R() const { return r; }
+            double R() const;
 
             /**
              * @brief The green part of the color
              * @return A reference to the statically green part of the color.
+             * @sharedapi
              */
-            double G() const { return g; }
+            double G() const;
             
             /**
              * @brief The blue part of the color
              * @return A reference to the statically blue part of the color.
+             * @sharedapi
              */
-            double B() const { return b; }
+            double B() const;
 
             /**
              * @brief The alpha part of the color
              * @return A reference to the statically alpha part of the color.
+             * @sharedapi
              */
-            double A() const { return a; }
+            double A() const;
 
         private:
             double r;

--- a/Component.hpp
+++ b/Component.hpp
@@ -13,6 +13,7 @@ namespace spic {
 
     /**
      * @brief Base class for all components.
+     * @spicapi
      */
     class Component {
         public:

--- a/Component.hpp
+++ b/Component.hpp
@@ -31,15 +31,14 @@ namespace spic {
             void Active(bool flag) { active = flag; }
 
             /**
-             * @brief The parent of this component
-             * @param parent the current parent
+             * @brief Get the GameObject this component belongs to.
              * @sharedapi
              */
             std::weak_ptr<spic::GameObject> GameObject() const;
 
             /**
-             * @brief The parent of this component
-             * @param parent the new parent
+             * @brief Set the GameObject this component belongs to.
+             * @param gameObject the GameObject this component belongs to.
              * @sharedapi
              */
             void GameObject(std::weak_ptr<spic::GameObject> gameObject);

--- a/Component.hpp
+++ b/Component.hpp
@@ -3,6 +3,10 @@
 
 #include <memory>
 
+#if __has_include("Component_includes.hpp")
+#include "Component_includes.hpp"
+#endif
+
 namespace spic {
 
     class GameObject;
@@ -28,21 +32,27 @@ namespace spic {
             /**
              * @brief The parent of this component
              * @param parent the current parent
+             * @sharedapi
              */
-            std::weak_ptr<spic::GameObject> GameObject() const { return _gameObject; }
+            std::weak_ptr<spic::GameObject> GameObject() const;
 
             /**
              * @brief The parent of this component
              * @param parent the new parent
+             * @sharedapi
              */
-            void GameObject(std::weak_ptr<spic::GameObject> gameObject) { _gameObject = gameObject; }
+            void GameObject(std::weak_ptr<spic::GameObject> gameObject);
 
         private:
             /**
              * @brief Active status.
+             * @spicapi
              */
             bool active;
-            std::weak_ptr<spic::GameObject> _gameObject;
+
+#if __has_include("Component_private.hpp")
+#include "Component_private.hpp"
+#endif
     };
 
 }

--- a/Debug.hpp
+++ b/Debug.hpp
@@ -9,6 +9,7 @@ namespace spic {
 
     /**
      * @brief Some convenient debugging functions.
+     * @spicapi
      */
     namespace Debug {
 

--- a/Engine.hpp
+++ b/Engine.hpp
@@ -9,6 +9,11 @@
 #endif
 
 namespace spic {
+
+    /**
+     * @brief The engine class responsible for the game loop.
+     * @sharedapi
+     */
     class Engine {
     private:
         static Engine instance;

--- a/EngineConfig.hpp
+++ b/EngineConfig.hpp
@@ -7,6 +7,7 @@ namespace spic {
 
     /**
      * @brief A struct representing the engine configuration.
+     * @sharedapi
      */
     struct EngineConfig {
 

--- a/GameObject.hpp
+++ b/GameObject.hpp
@@ -15,6 +15,7 @@ namespace spic {
 
     /**
      * @brief Any object which should be represented on screen.
+     * @spicapi
      */
     class GameObject {
         public:
@@ -205,50 +206,72 @@ namespace spic {
             /**
              * @brief Returns the transform of this GameObject
              * @return A reference to the transform
+             * @sharedapi
              */
             spic::Transform& Transform();
 
             /**
              * @brief Returns a const reference to the transform of this GameObject
              * @return A const reference to the transform
+             * @sharedapi
              */
             const spic::Transform& Transform() const;
 
             /**
              * The parent of this GameObject.
              * @return A weak pointer to the parent.
+             * @sharedapi
              */
             std::weak_ptr<GameObject> Parent();
 
             /**
              * The parent of this GameObject.
              * @param parent A weak pointer to the new parent
+             * @sharedapi
              */
             void Parent(std::weak_ptr<GameObject> parent);
 
             /**
              * Returns a list of children in this GameObject.
              * @return A list of shared pointers to the children.
+             * @sharedapi
              */
             const std::vector<std::shared_ptr<GameObject>>& Children() const;
 
             /**
              * Add a child to the children of this GameObject.
              * @param child the child to add.
+             * @sharedapi
              */
             void AddChild(std::shared_ptr<GameObject> child);
 
             /**
              * Remove a child from the children of this GameObject.
              * @param child the child to remove.
+             * @sharedapi
              */
             void RemoveChild(std::shared_ptr<GameObject> child);
 
-            const std::string& Name() { return name; }
+            /**
+             * Retrieve the name of this GameObject.
+             * @return the name of this GameObject.
+             * @sharedapi
+             */
+            const std::string& Name() const;
 
-            const std::string& Tag() { return tag; }
+            /**
+             * Retrieve the tag of this GameObject.
+             * @return the tag of this GameObject.
+             * @sharedapi
+             */
+            const std::string& Tag() const;
 
-            int Layer() { return layer; }
+            /**
+             * Retrieve the layer of this GameObject.
+             * @return the layer of this GameObject.
+             * @sharedapi
+             */
+            int Layer() const;
 
             // Include "package private" methods
 #if __has_include("GameObject_public.hpp")

--- a/IKeyListener.hpp
+++ b/IKeyListener.hpp
@@ -5,6 +5,7 @@ namespace spic {
 
     /**
      * @brief Interface for objects wanting to respond to keyboard events.
+     * @spicapi
      */
     class IKeyListener {
         public:

--- a/IMouseListener.hpp
+++ b/IMouseListener.hpp
@@ -5,6 +5,7 @@ namespace spic {
 
     /**
      * @brief Interface for objects wanting to respond to mouse events.
+     * @spicapi
      */
     class IMouseListener {
         public:

--- a/Input.hpp
+++ b/Input.hpp
@@ -14,6 +14,7 @@ namespace spic {
 
     /**
      * @brief Some convenient input functions.
+     * @spicapi
      */
     namespace Input {
 
@@ -338,24 +339,28 @@ namespace spic {
         /**
          * Register a new key listener
          * @param listener A reference to a key listener
+         * @sharedapi
          */
         void RegisterKeyListener(IKeyListener& listener);
 
         /**
          * Unregister a key listener
          * @param listener A reference to a key listener
+         * @sharedapi
          */
         void UnregisterKeyListener(IKeyListener& listener);
 
         /**
          * Register a new mouse listener
          * @param listener A reference to a mouse listener
+         * @sharedapi
          */
         void RegisterMouseListener(IMouseListener& listener);
 
         /**
          * Unregister a mouse listener
          * @param listener A reference to a mouse listener
+         * @sharedapi
          */
         void UnregisterMouseListener(IMouseListener& listener);
 

--- a/RigidBody.hpp
+++ b/RigidBody.hpp
@@ -8,6 +8,7 @@ namespace spic {
 
     /**
      * @brief Enumeration for different rigid body types
+     * @spicapi
      */
     enum class BodyType {
         staticBody,
@@ -17,6 +18,7 @@ namespace spic {
 
     /**
      * @brief A component representing a rigid body.
+     * @spicapi
      */
     class RigidBody : public Component {
         public:
@@ -25,6 +27,7 @@ namespace spic {
              * @param mass The mass of the rigid body
              * @param gravityScale The scale of the gravity of the rigid body
              * @param bodyType The type of the rigid body
+             * @sharedapi
              */
             RigidBody(double mass, double gravityScale, const BodyType& bodyType);
             

--- a/Scene.hpp
+++ b/Scene.hpp
@@ -14,6 +14,7 @@ namespace spic {
 
     /**
      * @brief Class representing a scene which can be rendered by the Camera.
+     * @spicapi
      */
     class Scene {
         public:

--- a/Sprite.hpp
+++ b/Sprite.hpp
@@ -20,6 +20,7 @@ namespace spic {
              * @param flipY The flip of the y-axis of the sprite
              * @param sortingLayer The layer the sprite will be sorted on
              * @param orderLayer The layer the sprite will be ordered on
+             * @sharedapi
              */
             Sprite(const std::string& sprite, bool flipX, bool flipY, int sortingLayer, int orderLayer);
             
@@ -31,78 +32,91 @@ namespace spic {
              * @param flipY The flip of the y-axis of the sprite
              * @param sortingLayer The layer the sprite will be sorted on
              * @param orderInLayer The layer the sprite will be ordered on
+             * @sharedapi
              */
             Sprite(const std::string& sprite, const Color& color, bool flipX, bool flipY, int sortingLayer, int orderInLayer);
 
             /**
              * @brief The texture of the sprite
              * @param sprite the path to the sprite
+             * @sharedapi
              */
             void Texture(const std::string& sprite);
 
             /**
              * @brief The texture of the sprite
              * @return The path of the sprite
+             * @sharedapi
              */
             const std::string& Texture() const;
 
             /**
              * @brief The color of the sprite
              * @param color the color
+             * @sharedapi
              */
             void Color(const spic::Color& color);
 
             /**
              * @brief The color of the sprite
              * @return the color
+             * @sharedapi
              */
             const spic::Color& Color() const;
 
             /**
              * @brief Whether the sprite should be flipped on the X-axis
              * @param flipX desired value
+             * @sharedapi
              */
             void FlipX(bool flipX);
 
             /**
              * @brief Whether the sprite should be flipped on the X-axis
              * @return current value
+             * @sharedapi
              */
             bool FlipX() const;
 
             /**
              * @brief Whether the sprite should be flipped on the Y-axis
              * @param flipY desired value
+             * @sharedapi
              */
             void FlipY(bool flipY);
 
             /**
              * @brief Whether the sprite should be flipped on the Y-axis
              * @return current value
+             * @sharedapi
              */
             bool FlipY() const;
 
             /**
              * @brief The layer the sprite will be sorted on
              * @param sortingLayer desired value
+             * @sharedapi
              */
             void SortingLayer(int sortingLayer);
 
             /**
              * @brief The layer the sprite will be sorted on
              * @return current value
+             * @sharedapi
              */
             int SortingLayer() const;
 
             /**
              * @brief The layer the sprite will be ordered on
              * @param orderInLayer desired value
+             * @sharedapi
              */
             void OrderInLayer(int orderInLayer);
 
             /**
              * @brief The layer the sprite will be ordered on
              * @return current value
+             * @sharedapi
              */
             int OrderInLayer() const;
 

--- a/Text.hpp
+++ b/Text.hpp
@@ -30,6 +30,7 @@ namespace spic {
              * @param layer The layer for the game object.
              * @param width The width of the UI object.
              * @param height The height of the UI object.
+             * @sharedapi
              */
             Text(const std::string& name, const std::string& tag, int layer, double width, double height);
             
@@ -45,66 +46,77 @@ namespace spic {
              * @param size The size the font will be rendered at
              * @param alignment The alignment the content will be rendered with 
              * @param color The color the content will be rendered in
+             * @sharedapi
              */
             Text(const std::string& name, const std::string& tag, int layer, double width, double height, const std::string& text, const std::string& font, int size, Alignment alignment, const Color& color);
 
             /**
              * @brief Get the content of the Text object
              * @return A reference to the content of the Text object
+             * @sharedapi
              */
             const std::string& Content() const;
 
             /**
              * @brief Set the text content of the Text object
              * @param text new content
+             * @sharedapi
              */
             void Content(const std::string& text);
 
             /**
              * @brief Get the font of the Text object
              * @return A reference to the font of the Text object
+             * @sharedapi
              */
             const std::string& Font() const;
 
             /**
              * @brief Set the font of the Text object
              * @param font the new font
+             * @sharedapi
              */
             void Font(const std::string& font);
 
             /**
              * @brief Get the size of the Text object
              * @return A reference to the size of the Text object
+             * @sharedapi
              */
             int Size() const;
 
             /**
              * @brief Set the size of the Text object
              * @param size the new size
+             * @sharedapi
              */
             void Size(int size);
 
             /**
              * @brief Get the alignment of the Text object
              * @return A reference to the alignment of the Text object
+             * @sharedapi
              */
             Alignment TextAlignment() const;
 
             /**
              * @brief Set the alignment of the content of the Text object
              * @param alignment the new alignment
+             * @sharedapi
              */
             void TextAlignment(Alignment alignment);
 
             /**
              * @brief Get the color of the Text object
              * @return A reference to the color of the Text object
+             * @sharedapi
              */
             const Color& TextColor() const;
 
             /**
              * @brief Set the color of the Text object
              * @param color the new color
+             * @sharedapi
              */
             void TextColor(const Color& color);
 

--- a/Time.hpp
+++ b/Time.hpp
@@ -5,6 +5,7 @@ namespace spic {
 
     /**
      * @brief Class representing game time.
+     * @spicapi
      */
     class Time {
         public:

--- a/UIObject.hpp
+++ b/UIObject.hpp
@@ -22,30 +22,35 @@ namespace spic {
              * @param layer The layer for the game object.
              * @param width The width of the UI object.
              * @param height The height of the UI object.
+             * @sharedapi
              */
             UIObject(const std::string& name, const std::string& tag, int layer, double width, double height);
 
             /**
              * @brief Get the width of the UIObject
              * @return The width of the UIObject
+             * @sharedapi
              */
             double Width() const;
 
             /**
              * @brief Set the width of the UIObject
              * @param newWidth The new width of the UIObject
+             * @sharedapi
              */
             void Width(double newWidth);
 
             /**
              * @brief Get the height of the UIObject
              * @return The height of the UIObject
+             * @sharedapi
              */
             double Height() const;
 
             /**
              * @brief Set the height of the UIObject
              * @param newHeight The new height of the UIObject
+             * @sharedapi
              */
             void Height(double newHeight);
 

--- a/WindowConfig.hpp
+++ b/WindowConfig.hpp
@@ -7,6 +7,7 @@ namespace spic {
 
     /**
      * @brief A struct representing the window configuration
+     * @sharedapi
      */
     struct WindowConfig {
 


### PR DESCRIPTION
Een heel flauwe PR,

Hebben t er met bob vd putten over gehad, we mogen alle implementatie/privates die door bob toegevoegd zijn lekker laten staan, maar onze eigen wel weghalen
Ja het is ook echt heel flauw, ook die paar kleuren die we zelf toegevoegd hebben gaat de implementatie eruit

heb ook gelijk:

* de deltatime setter omhoog verplaatst want ik ergerde me aan de volgorde
* spicapi/sharedapi toegevoegd waar miste