### PR TITLE
RFC 51: remove impl and rename color to not shadow

### DIFF
--- a/Color.cpp
+++ b/Color.cpp
@@ -18,17 +18,3 @@ Color Color::_transparent{0.0, 0.0, 0.0, 0.0};
 
 Color::Color(double red, double green, double blue, double alpha)
         : r{red}, g{green}, b{blue}, a{alpha} {}
-
-Color::Color(double red, double green, double blue)
-        : Color(red, green, blue, 1.0) {}
-
-void Color::SetColor(double r, double g, double b) {
-    SetColor(r, g, b, a);
-}
-
-void Color::SetColor(double r, double g, double b, double a) {
-    this->r = r;
-    this->g = g;
-    this->b = b;
-    this->a = a;
-}

--- a/Color.hpp
+++ b/Color.hpp
@@ -115,22 +115,22 @@ namespace spic {
 
             /**
              * @brief Set the RGB values of the color
-             * @param r The red part of the color
-             * @param g The green part of the color
-             * @param b The blue part of the color
+             * @param red The red part of the color
+             * @param green The green part of the color
+             * @param blue The blue part of the color
              * @sharedapi
              */
-            void SetColor(double r, double g, double b);
+            void SetColor(double red, double green, double blue);
 
             /**
              * @brief Set the RGBA values of the color
-             * @param r The red part of the color
-             * @param g The green part of the color
-             * @param b The blue part of the color
-             * @param a The alpha part of the color
+             * @param red The red part of the color
+             * @param green The green part of the color
+             * @param blue The blue part of the color
+             * @param alpha The alpha part of the color
              * @sharedapi
              */
-            void SetColor(double r, double g, double b, double a);
+            void SetColor(double red, double green, double blue, double alpha);
             
             /**
              * @brief The red part of the color


### PR DESCRIPTION
Als je r + g + b + a ipv de volle naam gebruikt shadowt ie de member naam en dat is nie tof, ook was ik vergeten die implementatie uit color.cpp te halen