### PR TITLE
RFC 53: update Camera constructor

### DIFF
--- a/Camera.hpp
+++ b/Camera.hpp
@@ -18,12 +18,15 @@ namespace spic {
         public:
             /**
              * @brief Constructor.
+             * @param tag The tag for the game object.
+             * @param layer The layer for the game object.
              * @param backgroundColor The background color of the horizon in the camera.
              * @param aspectWidth The aspect width of the camera.
              * @param aspectHeight The aspect width of the camera.
              * @sharedapi
              */
-            Camera(const Color& backgroundColor, double aspectWidth, double aspectHeight);
+            Camera(const std::string& name, int layer, const Color& backgroundColor,
+                   double aspectWidth, double aspectHeight);
 
             /**
              * Get the current background color.

--- a/Camera.hpp
+++ b/Camera.hpp
@@ -18,8 +18,8 @@ namespace spic {
         public:
             /**
              * @brief Constructor.
-             * @param tag The tag for the game object.
-             * @param layer The layer for the game object.
+             * @param name The name of the game object.
+             * @param layer The layer of the game object.
              * @param backgroundColor The background color of the horizon in the camera.
              * @param aspectWidth The aspect width of the camera.
              * @param aspectHeight The aspect width of the camera.


### PR DESCRIPTION
Omdat camera een Gameobject is heeft hij Name en Layer nodig in de constructor. (tag niet omdat dit wel altijd "camera" is)
Deze kunnen geen default value krijgen omdat we meerdere camera's willen kunnen hebben